### PR TITLE
Fixed git clone to place files in /gpuclass

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Instructions:
 
 3. Now clone the course with the following command:
 
-`git clone https://github.com/Azure/LearnAI-AIonIaaS`
+`git clone https://github.com/Azure/LearnAI-AIonIaaS /gpuclass`
 
 4. And link to it with the following command:
 


### PR DESCRIPTION
The git clone placed the files in ~/LearnAI-AIonIaaS, not in /gpuclass. Fixed the git clone command to place them in the correct folder.